### PR TITLE
Auto associate attachments

### DIFF
--- a/app/models/mailboxer/message.rb
+++ b/app/models/mailboxer/message.rb
@@ -68,7 +68,7 @@ class Mailboxer::Message < Mailboxer::Notification
     Mailboxer::Attachment.where(email_message_id: email_message_id)
                          .where(mailboxer_message_id: nil)
                          .each do |attachment|
-      attachment.update_attribute(mailboxer_message_id: id)
+      attachment.update_attributes(mailboxer_message_id: id)
     end
   end
 end

--- a/db/migrate/20190109092510_add_email_message_id_to_mailboxer_notification.rb
+++ b/db/migrate/20190109092510_add_email_message_id_to_mailboxer_notification.rb
@@ -1,4 +1,4 @@
-class AddEmailMessageIdToMailboxerAttachment < ActiveRecord::Migration
+class AddEmailMessageIdToMailboxerNotification < ActiveRecord::Migration
   def change
     add_column :mailboxer_notifications, :email_message_id, :string
     add_index :mailboxer_notifications, :email_message_id

--- a/db/migrate/20190109092510_add_email_message_id_to_mailboxer_notification.rb
+++ b/db/migrate/20190109092510_add_email_message_id_to_mailboxer_notification.rb
@@ -1,0 +1,6 @@
+class AddEmailMessageIdToMailboxerAttachment < ActiveRecord::Migration
+  def change
+    add_column :mailboxer_notifications, :email_message_id, :string
+    add_index :mailboxer_notifications, :email_message_id
+  end
+end

--- a/db/migrate/20190109092511_add_email_message_id_to_mailboxer_attachment.rb
+++ b/db/migrate/20190109092511_add_email_message_id_to_mailboxer_attachment.rb
@@ -1,0 +1,6 @@
+class AddEmailMessageIdToMailboxerAttachment < ActiveRecord::Migration
+  def change
+    add_column :mailboxer_attachments, :email_message_id, :string
+    add_index :mailboxer_attachments, :email_message_id
+  end
+end

--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -57,7 +57,7 @@ module Mailboxer
 
       #Sends a messages, starting a new conversation, with the messageable
       #as originator
-      def send_message(recipients, msg_body, subject, sanitize_text=true, attachment=nil, message_timestamp = Time.now)
+      def send_message(recipients, msg_body, subject, sanitize_text = true, attachment = nil, message_timestamp = Time.now, email_message_id = nil)
         convo = Mailboxer::ConversationBuilder.new({
           :subject    => subject,
           :created_at => message_timestamp,
@@ -65,14 +65,15 @@ module Mailboxer
         }).build
 
         message = Mailboxer::MessageBuilder.new({
-          :sender       => self,
-          :conversation => convo,
-          :recipients   => recipients,
-          :body         => msg_body,
-          :subject      => subject,
-          :attachment   => attachment,
-          :created_at   => message_timestamp,
-          :updated_at   => message_timestamp
+          :sender           => self,
+          :conversation     => convo,
+          :recipients       => recipients,
+          :body             => msg_body,
+          :subject          => subject,
+          :attachment       => attachment,
+          :email_message_id => email_message_id,
+          :created_at       => message_timestamp,
+          :updated_at       => message_timestamp
         }).build
 
         message.deliver false, sanitize_text
@@ -80,15 +81,16 @@ module Mailboxer
 
       #Basic reply method. USE NOT RECOMENDED.
       #Use reply_to_sender, reply_to_all and reply_to_conversation instead.
-      def reply(conversation, recipients, reply_body, subject=nil, sanitize_text=true, attachment=nil)
+      def reply(conversation, recipients, reply_body, subject = nil, sanitize_text = true, attachment = nil, email_message_id = nil)
         subject = subject || "#{conversation.subject}"
         response = Mailboxer::MessageBuilder.new({
-          :sender       => self,
-          :conversation => conversation,
-          :recipients   => recipients,
-          :body         => reply_body,
-          :subject      => subject,
-          :attachment   => attachment
+          :sender           => self,
+          :conversation     => conversation,
+          :recipients       => recipients,
+          :body             => reply_body,
+          :subject          => subject,
+          :attachment       => attachment,
+          :email_message_id => email_message_id
         }).build
 
         response.recipients.delete(self)

--- a/spec/dummy/db/migrate/20190109092510_add_email_message_id_to_mailboxer_notification.rb
+++ b/spec/dummy/db/migrate/20190109092510_add_email_message_id_to_mailboxer_notification.rb
@@ -1,0 +1,6 @@
+class AddEmailMessageIdToMailboxerAttachment < ActiveRecord::Migration
+  def change
+    add_column :mailboxer_notifications, :email_message_id, :string
+    add_index :mailboxer_notifications, :email_message_id
+  end
+end

--- a/spec/dummy/db/migrate/20190109092511_add_email_message_id_to_mailboxer_attachment.rb
+++ b/spec/dummy/db/migrate/20190109092511_add_email_message_id_to_mailboxer_attachment.rb
@@ -1,0 +1,6 @@
+class AddEmailMessageIdToMailboxerAttachment < ActiveRecord::Migration
+  def change
+    add_column :mailboxer_attachments, :email_message_id, :string
+    add_index :mailboxer_attachments, :email_message_id
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -32,9 +32,11 @@ ActiveRecord::Schema.define(version: 20170216173739) do
     t.integer  "mailboxer_message_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "email_message_id"
   end
 
   add_index "mailboxer_attachments", ["mailboxer_message_id"], name: "index_mailboxer_attachments_on_mailboxer_message_id"
+  add_index "mailboxer_attachments", ["email_message_id"], name: "index_mailboxer_attachments_on_email_message_id"
 
   create_table "mailboxer_conversation_opt_outs", force: :cascade do |t|
     t.integer "unsubscriber_id"
@@ -67,12 +69,14 @@ ActiveRecord::Schema.define(version: 20170216173739) do
     t.datetime "created_at",                           null: false
     t.boolean  "global",               default: false
     t.datetime "expires"
+    t.string   "email_message_id"
   end
 
   add_index "mailboxer_notifications", ["conversation_id"], name: "index_mailboxer_notifications_on_conversation_id"
   add_index "mailboxer_notifications", ["notified_object_id", "notified_object_type"], name: "index_mailboxer_notifications_on_notified_object_id_and_type"
   add_index "mailboxer_notifications", ["sender_id", "sender_type"], name: "index_mailboxer_notifications_on_sender_id_and_sender_type"
   add_index "mailboxer_notifications", ["type"], name: "index_mailboxer_notifications_on_type"
+  add_index "mailboxer_notifications", ["email_message_id"], name: "index_mailboxer_notifications_on_email_message_id"
 
   create_table "mailboxer_receipts", force: :cascade do |t|
     t.integer  "receiver_id"


### PR DESCRIPTION
Look up all orphaned attachments with a matching email_message_id (Message-ID) and associate them to the Mailboxer::Message with a matching email_message_id.

This is useful for cases where the message will be processed in a background job, as the attachments have to be stored temporarily before the message can be processed.